### PR TITLE
*fix missing column empty string

### DIFF
--- a/Angular-csv.ts
+++ b/Angular-csv.ts
@@ -173,15 +173,22 @@ export class AngularCsv {
         }
 
         if (this._options.nullToEmptyString) {
-            if(data === null) {
+            if(!data) {
                 return data = '';
+            }else{
+                return data;
             }
-            return data;
         }
         
         if (typeof data === 'boolean') {
             return data ? 'TRUE' : 'FALSE';
         }
+
+        //by default now if the user did not set nulltostring it will provide the conversion
+        if(!data){
+            return data = '';
+        }
+
         return data;
     }
 


### PR DESCRIPTION
Now the exporter should be able to convert null to strings and non values to empty strings also, by default